### PR TITLE
`numpy >= 1.26.4` for Python 3.12 and solve incompatibility with `pip-tools` version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ maintainers = [
 license = "MIT"
 readme = "README.md"
 dependencies = [
-    "numpy",
+    "numpy >= 1.26.4", # for Python 3.12
     "xarray",
     "networkx",
     "scipy", # required by netwokx but not automatically installed by pip
@@ -37,7 +37,7 @@ include = ["surface_sim", "surface_sim.*"]  # package names should match these g
 namespaces = false  # to disable scanning PEP 420 namespaces (true by default)
 
 [project.optional-dependencies]
-dev = ["pip-tools",
+dev = ["pip-tools>=7.5.3", # older versions are incompatible with newer pip versions
        "pytest",
        "ruff",
        "gprof2dot",

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ networkx==3.4.2
     # via surface-sim (pyproject.toml)
 numba==0.61.2
     # via galois
-numpy==1.24.4
+numpy==1.26.4
     # via
     #   cftime
     #   contourpy

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -91,7 +91,7 @@ pandas==2.2.2
     # via xarray
 pillow==11.1.0
     # via matplotlib
-pip-tools==7.4.1
+pip-tools==7.5.3
     # via surface-sim (pyproject.toml)
 pluggy==1.6.0
     # via pytest


### PR DESCRIPTION
Closes #417. 